### PR TITLE
Adding npm-run-all support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,8 @@ workflows:
   version: 2
   delivery:
     jobs:
-      - dependencies
+      - dependencies:
+            context: org-global
       - test:
           requires:
             - dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ workflows:
   delivery:
     jobs:
       - dependencies:
-            context: org-global
+          context: org-global
       - test:
           requires:
             - dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/app
   docker:
-    - image: circleci/node:8
+    - image: circleci/node:12
 
 version: 2
 jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statistician",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Create and compare files stats, and webpack bundle stats",
   "keywords": [
     "webpack-stats",
@@ -41,6 +41,7 @@
     "index-require": "^1.0.0",
     "marked": "^0.6.1",
     "node-fetch": "^2.3.0",
+    "npm-run-all": "^4.1.5",
     "yargs-parser": "^13.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Sometimes consumers choose to go with `npm-run-all` to execute it's build.