### PR TITLE
[CLI - GithubPullRequest] adding projectName argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statistician",
-  "version": "0.7.0-rc",
+  "version": "0.7.0",
   "description": "Create and compare files stats, and webpack bundle stats",
   "keywords": [
     "webpack-stats",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "await-reduce": "^1.2.3",
     "byte-size": "^5.0.1",
+    "chai": "^4.2.0",
     "chunkalyse": "^0.5.1",
     "fingerprinting": "^1.0.1",
     "index-require": "^1.0.0",
@@ -44,7 +45,6 @@
     "yargs-parser": "^21.0.1"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
     "async-execute": "^1.0.1",
     "chai-string": "^1.5.0",
     "clear-module": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   "dependencies": {
     "await-reduce": "^1.2.3",
     "byte-size": "^5.0.1",
-    "chai": "^4.2.0",
     "chunkalyse": "^0.5.1",
     "fingerprinting": "^1.0.1",
     "index-require": "^1.0.0",
     "jsonwebtoken": "^8.5.1",
     "marked": "^0.6.1",
     "node-fetch": "^2.3.0",
-    "yargs-parser": "^13.0.0"
+    "yargs-parser": "^21.0.1"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "async-execute": "^1.0.1",
     "chai-string": "^1.5.0",
     "clear-module": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statistician",
-  "version": "0.6.0",
+  "version": "0.7.0-rc",
   "description": "Create and compare files stats, and webpack bundle stats",
   "keywords": [
     "webpack-stats",

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -4,6 +4,15 @@ const bundles = require('./bundles');
 const files = require('./files');
 
 /**
+ * Formats a given project name expected to be at under_score format.
+ * @param projectName
+ * @returns {string}
+ */
+const formatProjectName = (projectName = '') => projectName.split('_')
+		.map((part) => [part[0].toUpperCase(), part.slice(1).toLowerCase()].join('') )
+		.join(' ');
+
+/**
  * Create the markdown for the pull request
  * @param  {Array} [options.bundle] Two objects (before, after)
  * @param  {Array} [options.files]  Two objects (before, after)
@@ -20,7 +29,7 @@ module.exports = async({bundle, file, html, projectName} = {}) => {
 	const diffTitle = !result.length ? 'No file size impact detected'
 			: [
 					'# File sizes impact summary',
-					projectName ? `(${projectName})` : false,
+					projectName ? ` (${formatProjectName(projectName)})` : false,
 			].filter(Boolean).join('');
 
 	result.unshift(

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -20,7 +20,7 @@ module.exports = async({bundle, file, html, projectName} = {}) => {
 	const diffTitle = !result.length ? 'No file size impact detected'
 			: [
 					'# File sizes impact summary',
-					projectName ? `(${projectName})` : false
+					projectName ? `(${projectName})` : false,
 			].filter(Boolean).join('');
 
 	result.unshift(

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -8,8 +8,8 @@ const files = require('./files');
  * @param projectName
  * @returns {string}
  */
-const formatProjectName = projectName => projectName.split('_')
-		.map((part) => [part[0].toUpperCase(), part.slice(1).toLowerCase()].join('') )
+const formatProjectName = (projectName = '') => projectName.split('_')
+		.map(part => [part[0].toUpperCase(), part.slice(1).toLowerCase()].join(''))
 		.join(' ');
 
 /**

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -8,7 +8,7 @@ const files = require('./files');
  * @param projectName
  * @returns {string}
  */
-const formatProjectName = (projectName = '') => projectName.split('_')
+const formatProjectName = projectName => projectName.split('_')
 		.map((part) => [part[0].toUpperCase(), part.slice(1).toLowerCase()].join('') )
 		.join(' ');
 

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -7,18 +7,25 @@ const files = require('./files');
  * Create the markdown for the pull request
  * @param  {Array} [options.bundle] Two objects (before, after)
  * @param  {Array} [options.files]  Two objects (before, after)
+ * @param  {Array} [options.html]
+ * @param  {Array} [options.projectName]
  * @return {String}
  */
-module.exports = async({bundle, file, html} = {}) => {
+module.exports = async({bundle, file, html, projectName} = {}) => {
 	const result = [];
 
 	bundle && result.push(await bundles(bundle));
 	file && result.push(await files(file));
 
-	result.unshift(
-		result.length ? '# File sizes impact summary' : 'No file size impact detected'
-	);
+	const diffTitle = !result.length ? 'No file size impact detected'
+			: [
+					'# File sizes impact summary',
+					projectName ? `(${projectName})` : false
+			].filter(Boolean).join('');
 
+	result.unshift(
+			diffTitle.trim()
+	);
 
 	const output = result.join('\n');
 

--- a/programs/github-pull-request/cli.js
+++ b/programs/github-pull-request/cli.js
@@ -11,15 +11,17 @@ const getJSON = require('../../lib/getJSON');
  * @param  {String} options.pr
  * @param  {String} options.bundle
  * @param  {String} options.file
+ * @param  {String} options.projectName
  * @return {Object}
  */
-module.exports = async({token, user, repo, pr, bundle, file, appId, appPrivateKey}) =>  program({
+module.exports = async({token, user, repo, pr, bundle, file, appId, appPrivateKey, projectName}) =>  program({
 	token,
 	appId,
 	appPrivateKey,
 	user,
 	repo,
 	pr,
+  projectName,
 
 	// before, after
 	bundle: bundle && await Promise.all(

--- a/programs/github-pull-request/index.js
+++ b/programs/github-pull-request/index.js
@@ -10,11 +10,12 @@ const pull = require('./pull');
  * @param  {String} options.user
  * @param  {String} options.repo
  * @param  {String} options.pr
+ * @param  {String} options.projectName
  * @param  {Array} options.bundle Two objects (before, after)
  * @param  {Array} options.file   Two objects (before, after)
  * @return {Object}
  */
-module.exports = async({token, user, repo, pr, bundle, file, appId, appPrivateKey}) => {
+module.exports = async({token, user, repo, pr, bundle, file, appId, appPrivateKey, projectName}) => {
 	if ([user, repo, pr].filter(notStringNorNumber).length) {
 		throw new Error([
 			'GitHub variables must be strings or numbers.',
@@ -23,7 +24,7 @@ module.exports = async({token, user, repo, pr, bundle, file, appId, appPrivateKe
 		].join(' '));
 	}
 
-	const message = await diffSummary({bundle, file});
+	const message = await diffSummary({bundle, file, projectName});
 
 	if (pr === true) { // `true` from yargs means an empty value (--pr --message "some message")
 		throw new Error('Pull-request entity is not available. I have nowhere to comment my findings ☹️');

--- a/programs/github-pull-request/index.js
+++ b/programs/github-pull-request/index.js
@@ -49,6 +49,7 @@ module.exports = async({token, user, repo, pr, bundle, file, appId, appPrivateKe
 		token,
 		user,
 		repo,
+    projectName,
 		pr,
 		message,
 	});

--- a/programs/github-pull-request/pull/index.js
+++ b/programs/github-pull-request/pull/index.js
@@ -7,11 +7,11 @@ const {name} = require('../../../package.json');
  * @param repo
  * @param projectName
  */
-const getCommentIdentifier = ({ repo, projectName }) => Buffer.from([
+const getCommentIdentifier = ({ repo, projectName }) => Buffer.from(projectName ? [
 		name,
 		repo,
 		projectName,
-].filter(Boolean).join('-')).toString('base64');
+].filter(Boolean).join('-') : name).toString('base64');
 
 /**
  * Create a pull request with the file and bundle stats comparison

--- a/programs/github-pull-request/pull/index.js
+++ b/programs/github-pull-request/pull/index.js
@@ -1,7 +1,17 @@
 const {join} = require('path');
 const GitHub = require('../../../lib/GitHub');
 const {name} = require('../../../package.json');
-const UNIQUE_IDENTIFIER = Buffer.from(name).toString('base64');
+
+/**
+ * Returns the Stats pull request comment identifier (to be later edited if needed)
+ * @param repo
+ * @param projectName
+ */
+const getCommentIdentifier = ({ repo, projectName }) => Buffer.from([
+		name,
+		repo,
+		projectName,
+].filter(Boolean).join('-')).toString('base64');
 
 /**
  * Create a pull request with the file and bundle stats comparison
@@ -10,19 +20,22 @@ const UNIQUE_IDENTIFIER = Buffer.from(name).toString('base64');
  * @param  {String} options.repo
  * @param  {String} options.pr
  * @param  {String} options.message
+ * @param  {String} options.projectName
  * @return {Object}
  */
-module.exports = async function pull({token, user, repo, pr, message}) {
+module.exports = async function pull({token, user, repo, pr, message, projectName}) {
 	const {request} = new GitHub({token});
 	if (pr === true) { // `true` from yargs means an empty value (--pr --message "some message")
 		throw new Error('Pull-request entity is not available. I have nowhere to comment my findings ☹️');
 	}
 
+	const commentIdentifier = getCommentIdentifier({repo, projectName});
+
 	const comments = await request(
 		path('repos', user, repo, 'issues', pr, 'comments')
 	);
 
-	const {id} = comments.find(comment => comment.body.includes(UNIQUE_IDENTIFIER)) || {id: ''};
+	const {id} = comments.find(comment => comment.body.includes(commentIdentifier)) || {id: ''};
 
 	const url = id ?
 		path('repos', user, repo, 'issues', 'comments', id) :
@@ -34,7 +47,7 @@ module.exports = async function pull({token, user, repo, pr, message}) {
 			method: id ? 'PATCH' : 'POST',
 			body: JSON.stringify({
 				body: [
-					`<!-- ${UNIQUE_IDENTIFIER} -->`,
+					`<!-- ${commentIdentifier} -->`,
 					message,
 				].join('\n'),
 			}),


### PR DESCRIPTION
**Main changes**
Adding support for `projectName` argument, to be attached over the `diff` summary.

This allows running multiple `stats` task over the same PR, providing a summary per entity.

**Side effects**
- Creating a uniq identifier per Stats comments, conditioned to a given project name, to allow multiple comments over the same PR.