### PR TITLE
[feat] No summary and no github comment if there is no significant file size changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statistician",
-  "version": "1.0.0-rc",
+  "version": "1.0.0",
   "description": "Create and compare files stats, and webpack bundle stats",
   "keywords": [
     "webpack-stats",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statistician",
-  "version": "0.7.0",
+  "version": "1.0.0-rc",
   "description": "Create and compare files stats, and webpack bundle stats",
   "keywords": [
     "webpack-stats",

--- a/programs/diff-summary/bundles/index.js
+++ b/programs/diff-summary/bundles/index.js
@@ -5,9 +5,6 @@ const deepEqual = require('../../../lib/deepEqual');
 const row = require('../../../lib/row');
 const keys = require('../../../lib/keys');
 
-const NO_CHANGES = 'Modules unchanged';
-const INSIGNIFICANT = 'No significant modules changes';
-
 /**
  * Create the markdown section for bundles
  * @param  {String} stats
@@ -17,13 +14,13 @@ module.exports = async function bundles(stats) {
 	const [before, after] = stats.map(chunkalyse);
 
 	if (deepEqual(before, after)) {
-		return NO_CHANGES;
+		return;
 	}
 
 	const body = compare(before, after);
 
 	if (body.length === 0) {
-		return INSIGNIFICANT;
+		return;
 	}
 
 	return [

--- a/programs/diff-summary/files/index.js
+++ b/programs/diff-summary/files/index.js
@@ -2,9 +2,6 @@ const markdown = require('./markdown');
 const deepEqual = require('../../../lib/deepEqual');
 const keys = require('../../../lib/keys');
 
-const NO_CHANGES = 'Files unchanged';
-const INSIGNIFICANT = 'No significant file changes';
-
 /**
  * Create the markdown section for files
  * @param  {String} files

--- a/programs/diff-summary/files/index.js
+++ b/programs/diff-summary/files/index.js
@@ -12,7 +12,7 @@ const INSIGNIFICANT = 'No significant file changes';
  */
 module.exports = async function files([before, after]) {
 	if (deepEqual(before, after)) {
-		return NO_CHANGES;
+		return;
 	}
 
 	const comparison = compare(before, after);
@@ -20,7 +20,7 @@ module.exports = async function files([before, after]) {
 	const filesTable = markdown(comparison);
 
 	if (!filesTable) {
-		return INSIGNIFICANT;
+		return;
 	}
 
 	return [

--- a/programs/diff-summary/files/spec.js
+++ b/programs/diff-summary/files/spec.js
@@ -5,22 +5,20 @@ describe('files', async() => {
 		files = require('.');
 	});
 
-	it('Should claim "unchanged" when the objects are identical', async() => {
+	it('Should return undefined when the objects are identical', async() => {
 		const result = await files([
 			{one: 1000, two: 1000},
 			{one: 1000, two: 1000},
 		]);
-		expect(result).to.include('Files unchanged');
-		expect(result).to.not.include('\n');
+		expect(result).to.equal(undefined);
 	});
 
-	it('Should claim "unsignificant" when the objects are extremely close', async() => {
+	it('Should return undefined when the objects are extremely close', async() => {
 		const result = await files([
 			{one: 1001, two: 1000},
 			{one: 1000, two: 1001},
 		]);
-		expect(result).to.include('No significant');
-		expect(result).to.not.include('\n');
+		expect(result).to.equal(undefined);
 	});
 
 	it('Should build a table if there are differences', async() => {

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -26,11 +26,14 @@ module.exports = async({bundle, file, html, projectName} = {}) => {
 	bundle && result.push(await bundles(bundle));
 	file && result.push(await files(file));
 
-	const diffTitle = !result.length ? 'No file size impact detected'
-			: [
-					'# File sizes impact summary',
-					projectName ? ` (${formatProjectName(projectName)})` : false,
-			].filter(Boolean).join('');
+	if (result.length === 0) {
+		return '';
+	}
+
+	const diffTitle = [
+		'# File sizes impact summary',
+		projectName ? ` (${formatProjectName(projectName)})` : false,
+	].filter(Boolean).join('');
 
 	result.unshift(
 			diffTitle.trim()

--- a/programs/diff-summary/index.js
+++ b/programs/diff-summary/index.js
@@ -26,7 +26,7 @@ module.exports = async({bundle, file, html, projectName} = {}) => {
 	bundle && result.push(await bundles(bundle));
 	file && result.push(await files(file));
 
-	if (result.length === 0) {
+	if (!result.some(res => res)) {
 		return '';
 	}
 

--- a/programs/diff-summary/spec.js
+++ b/programs/diff-summary/spec.js
@@ -12,8 +12,8 @@ describe('diff-summary', () => {
 		delete require.cache[require.resolve('chunkalyse')];
 	});
 
-	it('Should report no file size impact', async() => {
-		expect(await diffSummary()).to.equalIgnoreCase('No file size impact detected')
+	it('Should be empty when no file size impact', async() => {
+		expect(await diffSummary()).to.equal('')
 	});
 	it('Should compare files', async() => {
 		const result = await diffSummary({file: [fixtures.files.before, fixtures.files.after]});

--- a/programs/github-pull-request/pull/index.js
+++ b/programs/github-pull-request/pull/index.js
@@ -41,16 +41,23 @@ module.exports = async function pull({token, user, repo, pr, message, projectNam
 		path('repos', user, repo, 'issues', 'comments', id) :
 		path('repos', user, repo, 'issues', pr, 'comments');
 
+	if (!message && !id) {
+		return;
+	}
+
+	const method = id ? !message ? 'DELETE': 'PATCH' : 'POST';
+	const body = !message ? undefined : JSON.stringify({
+		body: [
+			`<!-- ${commentIdentifier} -->`,
+			message,
+		].join('\n'),
+	});
+
 	return await request(
 		url,
 		{
-			method: id ? 'PATCH' : 'POST',
-			body: JSON.stringify({
-				body: [
-					`<!-- ${commentIdentifier} -->`,
-					message,
-				].join('\n'),
-			}),
+			method,
+			body,
 		}
 	);
 }


### PR DESCRIPTION
In order to reduce github comment that don't have added value:

- Return empty summary if there is no significant change
- Do not add github comment if there is no significant change, and delete relevant past comment if needed.