### PR TITLE
feat: Support 64bit hashes

### DIFF
--- a/lib/removeFingerprint/index.js
+++ b/lib/removeFingerprint/index.js
@@ -8,7 +8,7 @@ const { readFile } = require('../afsync');
  * @return {String}
  */
 
-const FINGERPRINT_PATTERN = /[a-f0-9]{20}/;
+const FINGERPRINT_PATTERN = /[a-f0-9]{16,20}/;
 
 module.exports = async function removeFingerprint(path) {
     const content = await readFile(path);

--- a/lib/removeFingerprint/index.js
+++ b/lib/removeFingerprint/index.js
@@ -8,7 +8,8 @@ const { readFile } = require('../afsync');
  * @return {String}
  */
 
-const FINGERPRINT_PATTERN = /[a-f0-9]{16,20}/;
+const FINGERPRINT_PATTERN = /[a-f0-9]{20}/;
+const XXHASH64_HEXA_PATTERN = /[a-f0-9]{16}/;
 
 module.exports = async function removeFingerprint(path) {
     const content = await readFile(path);
@@ -20,5 +21,6 @@ module.exports = async function removeFingerprint(path) {
     return path.split('.')
         .filter(part => !id.startsWith(part))
         .filter(part => !FINGERPRINT_PATTERN.test(part))
+        .filter(part => !XXHASH64_HEXA_PATTERN.test(part))
         .join('.');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statistician",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Create and compare files stats, and webpack bundle stats",
   "keywords": [
     "webpack-stats",


### PR DESCRIPTION
Some hash algorithms (Like the `xxhash64` hashing algorithm used by Rspack) only produce 64bit outputs which allow maximum of 16 hexadecimal characters. At 4 bits per hex character: `64 / 4 = 16`

The existing code only removes 20 character hashes from the filenames of the output files.
So this PR add a check for 16 character hashes as well.