### PR TITLE
chore(ci): migrate CircleCI config to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults: &defaults
   docker:
     - image: cimg/node:14.19
 
-version: 2
+version: 2.1
 jobs:
   install:
     <<: *defaults


### PR DESCRIPTION
## What
Bump the CircleCI config from `version: 2` to `version: 2.1` — a single-line change.

## Why
CircleCI is [sunsetting configuration version 2.0](https://discuss.circleci.com/t/breaking-change-sunsetting-configuration-version-2-0/54605) on **2026-06-27**. After that date, pipelines on v2.0 stop working.

## Safety
- Only the top-level `version` line changes — no job, workflow, executor, or step is touched.
- Validated with `circleci config validate` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
